### PR TITLE
Use language neutral link to the Firefox extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ IITC-Button WebExtension
 
 Intel map of Ingress game with IITC-CE in your browser.
 
-Get it on [Firefox Add-ons](https://addons.mozilla.org/ru/firefox/addon/iitc-button) and [Chrome Web Store](https://chrome.google.com/webstore/detail/iitc-button/febaefghpimpenpigafpolgljcfkeakn)
+Get it on [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/iitc-button) and [Chrome Web Store](https://chrome.google.com/webstore/detail/iitc-button/febaefghpimpenpigafpolgljcfkeakn)
 
 ---
 


### PR DESCRIPTION
Remove the /ru/ so AMO will show the page in the user's language